### PR TITLE
test to add ATTRS for MODULE, which specifies some module attributes

### DIFF
--- a/src/builder/exp_builder.cpp
+++ b/src/builder/exp_builder.cpp
@@ -67,7 +67,12 @@ IModule *ExpBuilder::BuildModule(Exp *e, IDesign *design) {
     return nullptr;
   }
   IModule *module = new IModule(design, e->vec[1]->atom.str);
-  for (int i = 2; i < e->vec.size(); ++i) {
+  int i = 2;
+  if (e->vec[i]->vec[0]->atom.str == "ATTRS") {
+      BuildModuleAttrs(e->vec[i], module);
+      ++i;
+  }
+  for (; i < e->vec.size(); ++i) {
     if (e->vec[i]->vec.size() == 0) {
       SetError();
     } else if (e->vec[i]->vec[0]->atom.str == "TABLE") {
@@ -315,6 +320,21 @@ ostream &ExpBuilder::SetError() {
 
 bool ExpBuilder::HasError() {
   return has_error_;
+}
+
+void ExpBuilder::BuildModuleAttrs(Exp *e, IModule *module) {
+  for (int i = 1; i < e->vec.size(); ++i) {
+    Exp *t = e->vec[i];
+    if(t->vec[0]->atom.str == "RESET-POLARITY"){
+      if(t->vec[1]->atom.str == "true"){
+	module->SetResetPolarity(true);
+      }else{
+	module->SetResetPolarity(false);
+      }
+    }else if(t->vec[0]->atom.str == "RESET-NAME"){
+      module->SetResetName(t->vec[1]->atom.str);
+    }
+  }
 }
 
 }  // namespace builder

--- a/src/builder/exp_builder.h
+++ b/src/builder/exp_builder.h
@@ -37,6 +37,7 @@ private:
   void BuildResourceParams(Exp *e, ResourceParams *params);
   void BuildParamTypes(Exp *e, vector<IValueType> *types);
   bool HasError();
+  void BuildModuleAttrs(Exp *e, IModule *module);
 
   bool has_error_;
   ostringstream errors_;

--- a/src/iroha/i_design.cpp
+++ b/src/iroha/i_design.cpp
@@ -318,6 +318,22 @@ IModule *IModule::GetParentModule() const {
   return parent_;
 }
 
+const string &IModule::GetResetName() const {
+  return reset_name_;
+}
+
+const bool &IModule::GetResetPolarity() const {
+  return reset_polarity_;
+}
+
+void IModule::SetResetName(string n) {
+  reset_name_ = n;
+}
+
+void IModule::SetResetPolarity(bool v) {
+  reset_polarity_ = v;
+}
+
 IDesign::IDesign()
   : objects_(new ObjectPool), params_(new ResourceParams), annotation_(nullptr) {
   resource::InstallResourceClasses(this);

--- a/src/iroha/i_design.h
+++ b/src/iroha/i_design.h
@@ -221,10 +221,17 @@ public:
 
   vector<ITable *> tables_;
 
+  const string &GetResetName() const;
+  const bool &GetResetPolarity() const;
+  void SetResetName(string n);
+  void SetResetPolarity(bool v);
+
 private:
   IDesign *design_;
   string name_;
   IModule *parent_;
+  string reset_name_ = "rst_n";
+  bool reset_polarity_ = false;
 };
 
 // Represents a whole design including module hierarchy,

--- a/src/writer/verilog/module.cpp
+++ b/src/writer/verilog/module.cpp
@@ -19,7 +19,8 @@ Module::Module(const IModule *i_mod, const Connection &conn, Embed *embed)
   : i_mod_(i_mod), conn_(conn), embed_(embed) {
   tmpl_.reset(new ModuleTemplate);
   ports_.reset(new Ports);
-  reset_polarity_ = i_mod_->GetDesign()->GetParams()->GetResetPolarity();
+  //  reset_polarity_ = i_mod_->GetDesign()->GetParams()->GetResetPolarity();
+  reset_polarity_ = i_mod_->GetResetPolarity();
 }
 
 Module::~Module() {
@@ -64,11 +65,12 @@ const Ports *Module::GetPorts() const {
 
 void Module::Build() {
   ports_->AddPort("clk", Port::INPUT_CLK, 0);
-  if (reset_polarity_) {
-    ports_->AddPort("rst", Port::INPUT_RESET, 0);
-  } else {
-    ports_->AddPort("rst_n", Port::INPUT_RESET, 0);
-  }
+  //  if (module->reset_polarity_) {
+  //    ports_->AddPort("rst", Port::INPUT_RESET, 0);
+  //  } else {
+  //    ports_->AddPort("rst_n", Port::INPUT_RESET, 0);
+  //  }
+  ports_->AddPort(i_mod_->GetResetName(), Port::INPUT_RESET, 0);
 
   for (auto *i_table : i_mod_->tables_) {
     Table *tab = new Table(i_table, ports_.get(), this, embed_,

--- a/src/writer/verilog/table.cpp
+++ b/src/writer/verilog/table.cpp
@@ -212,7 +212,15 @@ void Table::BuildRegister() {
 	rs << "  reg";
       }
       rs << " " << WidthSpec(reg);
-      rs << " " << reg->GetName() << ";\n";
+      rs << " " << reg->GetName();
+      if(reg->HasInitialValue()){
+	int width = reg->value_type_.GetWidth();
+	width = width == 0 ? 1 : width;
+	rs << " = " << width << "\'d" << reg->GetInitialValue().value_ << ";\n";
+      }else{
+	rs << ";\n";
+      }
+      //rs << " " << reg->GetName() << ";\n";
     }
     if (!reg->IsConst() && reg->HasInitialValue()) {
       is << "      " << reg->GetName() << " <= "


### PR DESCRIPTION
Moduleレベルの属性として，リセット信号の名前やリセットの極性を決めたいと思っています．

そこで，ATTRSというリストをMODULEに定義できるように追加しました．
また，Verilogを生成するときにはATTRSで指定されたリセット名や極性を使用するように変更してみています．
ATTRSは省略可能で，省略した場合にはデフォルト値を使用します．
ATTRSの使用例は↓をご覧ください．
https://github.com/synthesijer/synthesijer/blob/master/sample/iroha/Min001.iroha
